### PR TITLE
sync Claude plugin (cd2c3e1)

### DIFF
--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -13,7 +13,7 @@ Web scraping, search, and page interaction CLI. Returns clean markdown optimized
 
 Run `firecrawl --help` or `firecrawl <command> --help` for full option details.
 
-If the task is to integrate Firecrawl into an application, add `FIRECRAWL_API_KEY` to a project, or choose endpoint usage in product code, use the Firecrawl skills repo instead of relying on this CLI skill alone: `npx skills add firecrawl/skills`.
+If the task is to integrate Firecrawl into an application, add `FIRECRAWL_API_KEY` to a project, or choose endpoint usage in product code, use the `firecrawl-build` skills. They are already installed alongside this CLI skill when you run `firecrawl init`.
 
 ## Prerequisites
 
@@ -87,7 +87,7 @@ For detailed command reference, run `firecrawl <command> --help`.
 - **Downloading a site to local files** -> [firecrawl-download](../firecrawl-download/SKILL.md)
 - **Install, auth, or setup problems** -> [rules/install.md](rules/install.md)
 - **Output handling and safe file-reading patterns** -> [rules/security.md](rules/security.md)
-- **Integrating Firecrawl into an app, adding `FIRECRAWL_API_KEY` to `.env`, or choosing endpoint usage in product code** -> install the Firecrawl skills repo with `npx skills add firecrawl/skills`
+- **Integrating Firecrawl into an app, adding `FIRECRAWL_API_KEY` to `.env`, or choosing endpoint usage in product code** -> use the `firecrawl-build` skills (already installed alongside this CLI skill)
 
 ## Output & Organization
 


### PR DESCRIPTION
Automated sync of `skills/firecrawl-cli` and `.claude-plugin` from [firecrawl/cli@cd2c3e1](https://github.com/firecrawl/cli/commit/cd2c3e1e013012ab8f08b0220afc08f18c824e71).