### PR TITLE
add firecrawl parse skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "firecrawl",
       "source": "./",
-      "description": "Scrape, search, crawl, and map the web with a single command.",
-      "skills": ["./skills/firecrawl-cli"]
+      "description": "Scrape, search, crawl, map the web, and parse local documents with Firecrawl.",
+      "skills": ["./skills/firecrawl-cli", "./skills/firecrawl-parse"]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
     "name": "firecrawl",
-    "description": "Scrape, search, crawl, and map the web with a single command.",
+    "description": "Scrape, search, crawl, map the web, and parse local documents with Firecrawl.",
     "version": "1.0.8",
     "author": {
         "name": "Firecrawl"
     },
-    "skills": ["./skills/firecrawl-cli"]
+    "skills": ["./skills/firecrawl-cli", "./skills/firecrawl-parse"]
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Firecrawl Plugin for Claude Code
 
-Turn any website into clean, LLM-ready markdown or structured data — directly from Claude Code.
+Turn websites and documents into clean, LLM-ready markdown or structured data directly from Claude Code.
 
-This plugin adds the [Firecrawl CLI](https://github.com/firecrawl/cli) as a skill to Claude Code, giving it the ability to scrape, search, crawl, and map the web.
+This plugin adds the [Firecrawl CLI](https://github.com/firecrawl/cli) as a skill to Claude Code, giving it the ability to scrape, search, crawl, map the web, and parse local documents.
 
 ## Features
 
@@ -10,6 +10,7 @@ This plugin adds the [Firecrawl CLI](https://github.com/firecrawl/cli) as a skil
 - **Scrape** - Extract clean markdown content from any webpage, with JavaScript rendering
 - **Map** - Discover all URLs on a website
 - **Crawl** - Extract content from entire websites
+- **Parse** - Convert local PDF, DOCX, XLSX, and HTML files with `/v2/parse`
 - **Browser** - Launch cloud browser sessions and execute Playwright code remotely
 
 All operations include automatic JavaScript rendering, anti-bot handling, and proxy rotation.
@@ -77,6 +78,11 @@ Scrape https://docs.firecrawl.dev/introduction and summarize the key points
 Map all URLs on https://firecrawl.dev
 ```
 
+**Parse a local document:**
+```
+Parse ./report.pdf and summarize the key findings
+```
+
 **Research a topic:**
 ```
 Research the latest developments in AI agents and give me a summary
@@ -90,6 +96,7 @@ The plugin uses these Firecrawl CLI commands under the hood:
 |---------|-------------|
 | `firecrawl search "query"` | Search the web (supports `--sources`, `--scrape`, `--tbs` for time filters) |
 | `firecrawl scrape <url>` | Scrape a single page to markdown |
+| `firecrawl parse <file>` | Parse a local PDF, DOCX, XLSX, or HTML file |
 | `firecrawl map <url>` | Discover all URLs on a site |
 | `firecrawl browser launch/execute/list/close` | Manage cloud browser sessions and execute Playwright code |
 | `firecrawl --status` | Check auth status, concurrency, and credits |

--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: firecrawl
 description: |
-  Search, scrape, and interact with the web via the Firecrawl CLI. Use this skill whenever the user wants to search the web, find articles, research a topic, look something up online, scrape a webpage, grab content from a URL, get data from a website, crawl documentation, download a site, or interact with pages that need clicks or logins. Also use when they say "fetch this page", "pull the content from", "get the page at https://", or reference external websites. This provides real-time web search with full page content and interact capabilities — beyond what Claude can do natively with built-in tools. Do NOT trigger for local file operations, git commands, deployments, or code editing tasks.
+  Search, scrape, parse, and interact with content via the Firecrawl CLI. Use this skill whenever the user wants to search the web, find articles, research a topic, look something up online, scrape a webpage, grab content from a URL, parse a local document, get data from a website, crawl documentation, download a site, or interact with pages that need clicks or logins. Also use when they say "fetch this page", "pull the content from", "get the page at https://", "parse this PDF", "read this document", or reference external websites or supported local document files. This provides real-time web search, full page content extraction, document parsing, and interact capabilities beyond what Claude can do natively. Do NOT trigger for unrelated local file operations, git commands, deployments, or code editing tasks.
 allowed-tools:
   - Bash(firecrawl *)
   - Bash(npx firecrawl *)
@@ -9,7 +9,7 @@ allowed-tools:
 
 # Firecrawl CLI
 
-Search, scrape, and interact with the web. Returns clean markdown optimized for LLM context windows.
+Search, scrape, parse, and interact with content. Returns clean markdown optimized for LLM context windows.
 
 Run `firecrawl --help` or `firecrawl <command> --help` for full option details.
 
@@ -52,6 +52,7 @@ Follow this escalation pattern:
 3. **Map + Scrape** - Large site or need a specific subpage. Use `map --search` to find the right URL, then scrape it.
 4. **Crawl** - Need bulk content from an entire site section (e.g., all /docs/).
 5. **Interact** - Scrape first, then interact with the page (pagination, modals, form submissions, multi-step navigation).
+6. **Parse** - Have a local or non-public document file. Upload the file bytes to `/v2/parse`.
 
 | Need                        | Command               | When                                                      |
 | --------------------------- | --------------------- | --------------------------------------------------------- |
@@ -62,7 +63,7 @@ Follow this escalation pattern:
 | AI-powered data extraction  | `agent`               | Need structured data from complex sites                   |
 | Interact with a page        | `scrape` + `interact` | Content requires clicks, form fills, pagination, or login |
 | Download a site to files    | `download`            | Save an entire site as local files                        |
-| Parse a local file          | `parse`               | File on disk (PDF, DOCX, XLSX, etc.) — not a URL          |
+| Parse a local file          | `parse`               | File on disk (PDF, DOCX, XLSX, etc.) - not a URL          |
 
 For detailed command reference, run `firecrawl <command> --help`.
 

--- a/skills/firecrawl-parse/SKILL.md
+++ b/skills/firecrawl-parse/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: firecrawl-parse
+description: |
+  Parse local or non-public documents with Firecrawl /v2/parse. Use this skill when the user provides a local file path or asks to parse, read, convert, summarize, or ask questions about a document on disk, including PDF, DOCX, DOC, ODT, RTF, XLSX, XLS, HTML, or HTM files. Prefer this over scrape for local files; use scrape instead when the source is a public document URL.
+allowed-tools:
+  - Bash(firecrawl *)
+  - Bash(npx firecrawl *)
+---
+
+# firecrawl parse
+
+Turn a local document into clean, LLM-ready output with Firecrawl `/v2/parse`. Supports `.pdf`, `.docx`, `.doc`, `.odt`, `.rtf`, `.xlsx`, `.xls`, `.html`, and `.htm` files.
+
+## When to use
+
+- The source is a file on disk, uploaded by the user, or otherwise not publicly accessible by URL
+- The user asks to parse, read, convert, summarize, or ask questions about a local document
+- Use `firecrawl scrape` instead when the source is a public URL to a document; scrape auto-detects supported document files from extension or content type
+
+## Quick start
+
+Always write parse output to `.firecrawl/` with `-o`; parsed documents can be large.
+
+```bash
+mkdir -p .firecrawl
+
+# File to markdown
+firecrawl parse "./report.pdf" -o .firecrawl/report.md
+
+# Include multiple output formats
+firecrawl parse "./report.pdf" --format markdown,links --json --pretty \
+  -o .firecrawl/report.json
+
+# Summary
+firecrawl parse "./contract.docx" --summary -o .firecrawl/contract-summary.md
+
+# Ask a question about the document
+firecrawl parse "./invoice.pdf" --query "What is the total amount due?" \
+  -o .firecrawl/invoice-answer.md
+```
+
+Read outputs incrementally with `head`, `rg`, `wc`, or `sed` instead of loading large files all at once.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `-f, --format <formats>` | Output formats: `markdown`, `html`, `rawHtml`, `links`, `images`, `summary`, `json`, `attributes` |
+| `-H, --html` | Shortcut for `--format html` |
+| `-S, --summary` | Shortcut for `--format summary` |
+| `-Q, --query <prompt>` | Ask a question about the parsed content |
+| `--only-main-content` | Include only main content |
+| `--include-tags <tags>` | Comma-separated HTML tags to include |
+| `--exclude-tags <tags>` | Comma-separated HTML tags to exclude |
+| `--timeout <ms>` | Timeout for the parse job |
+| `--json` | Emit JSON output |
+| `--pretty` | Pretty-print JSON output |
+| `-o, --output <path>` | Output file path; prefer `.firecrawl/` |
+
+## Tips
+
+- Quote paths with spaces: `firecrawl parse "./My Report.pdf" -o .firecrawl/my-report.md`.
+- Max upload size is 50 MB per request.
+- `/v2/parse` accepts local file bytes via multipart form upload. Do not print API keys or multipart payloads to logs.
+- For public PDF, DOCX, XLSX, or HTML URLs, prefer `firecrawl scrape "<url>" -o .firecrawl/page.md`.
+- Check `.firecrawl/` before parsing the same file again.
+- Check credits before batch work with `firecrawl credit-usage`.
+
+## See also
+
+- [firecrawl-scrape](../firecrawl-scrape/SKILL.md) - parse document URLs or scrape webpages
+- [firecrawl-cli](../firecrawl-cli/SKILL.md) - full Firecrawl CLI workflow


### PR DESCRIPTION
## Summary
- add a dedicated `firecrawl-parse` skill for local and non-public documents using `/v2/parse`
- expose the parse skill in the Claude plugin manifests
- update README and the main Firecrawl skill trigger text so local document parsing is discoverable

## Docs checked
- https://docs.firecrawl.dev/features/document-parsing
- https://docs.firecrawl.dev/api-reference/endpoint/parse

## Validation
- `npx -y firecrawl-cli@1.16.2 parse --help`
- `jq . .claude-plugin/plugin.json`
- `jq . .claude-plugin/marketplace.json`
- `git diff --check`