### PR TITLE
sync Claude plugin skills (cb00942)

### DIFF
--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -279,6 +279,25 @@ The most useful field is `--missing-content`: an _array_ of specific pieces of c
 
 **Opt out:** `export FIRECRAWL_NO_SEARCH_FEEDBACK=1` makes the CLI skip every feedback call silently. Respect that flag — do not try to work around it. See [firecrawl-search](../firecrawl-search/SKILL.md) for the full pattern.
 
+## Endpoint job feedback
+
+For non-search endpoint jobs, use `firecrawl feedback <endpoint> <jobId>` to send concise job-level feedback through `/v2/feedback`. Supported endpoints are `search`, `scrape`, `parse`, and `map`.
+
+```bash
+firecrawl feedback scrape "$SCRAPE_ID" \
+  --rating partial \
+  --issues missing_markdown \
+  --tags docs \
+  --note "The pricing table was missing from the markdown output." \
+  --url "https://example.com/pricing" \
+  --page-numbers 1 \
+  --silent &
+```
+
+Keep generic feedback small: issue codes, tags, short notes, URLs, page numbers, and small metadata objects. Do not send raw scrape/parse outputs or full page contents as feedback.
+
+**Opt out:** `export FIRECRAWL_NO_ENDPOINT_FEEDBACK=1` makes the CLI skip every endpoint feedback call silently. Respect that flag — do not try to work around it.
+
 ## Parallelization
 
 Run independent operations in parallel. Check `firecrawl --status` for concurrency limit:


### PR DESCRIPTION
Automated sync of `skills/` and `.claude-plugin` from [firecrawl/cli@cb00942](https://github.com/firecrawl/cli/commit/cb009428ab15dc4117ca8421048bf388a4367fa9).