### PR TITLE
sync Claude plugin skills (278556b)

### DIFF
--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -17,7 +17,7 @@ If the task is to integrate Firecrawl into an application, add `FIRECRAWL_API_KE
 
 ## Prerequisites
 
-Must be installed and authenticated. Check with `firecrawl --status`.
+Must be installed. Check with `firecrawl --status`.
 
 ```
   🔥 firecrawl cli v1.8.0
@@ -29,6 +29,8 @@ Must be installed and authenticated. Check with `firecrawl --status`.
 
 - **Concurrency**: Max parallel jobs. Run parallel operations up to this limit.
 - **Credits**: Remaining API credits. Each operation consumes credits.
+
+Authenticating gives the best results. Prefer a free account via `firecrawl init --browser` (browser login) or a `FIRECRAWL_API_KEY` whenever the human can sign up. If you cannot obtain a key and the human cannot sign up, you can still search, scrape, and interact without an API key on the keyless free tier (rate-limited). See [agent onboarding](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for the full set of onboarding paths.
 
 If not ready, see [rules/install.md](rules/install.md). For output handling guidelines, see [rules/security.md](rules/security.md).
 

--- a/skills/firecrawl-cli/rules/install.md
+++ b/skills/firecrawl-cli/rules/install.md
@@ -74,6 +74,8 @@ Ask the user how they'd like to authenticate:
 1. **Login with browser (Recommended)** - Run `firecrawl login --browser`
 2. **Enter API key manually** - Run `firecrawl login --api-key "<key>"` with a key from firecrawl.dev
 
+If you cannot obtain a key and the user cannot sign up, search, scrape, and interact still work without an API key on the keyless free tier (rate-limited). Browser login or an API key remains preferred for the best results. See [agent onboarding](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for the full set of onboarding paths.
+
 ### Command not found
 
 If `firecrawl` is not found after installation:


### PR DESCRIPTION
Automated sync of `skills/` and `.claude-plugin` from [firecrawl/cli@278556b](https://github.com/firecrawl/cli/commit/278556bae624018b1c63a54ed1977281b110351b).