### PR TITLE
fix: correct skill name to match directory name in firecrawl-cli

### DIFF
--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: firecrawl
+name: firecrawl-cli
 description: |
   Search, scrape, and interact with the web via the Firecrawl CLI. Use this skill whenever the user wants to search the web, find articles, research a topic, look something up online, scrape a webpage, grab content from a URL, get data from a website, crawl documentation, download a site, or interact with pages that need clicks or logins. Also use when they say "fetch this page", "pull the content from", "get the page at https://", or reference external websites. This provides real-time web search with full page content and interact capabilities — beyond what Claude can do natively with built-in tools. Do NOT trigger for local file operations, git commands, deployments, or code editing tasks.
 allowed-tools:


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `skills/firecrawl-cli/SKILL.md` has `name: firecrawl` in its frontmatter, but the parent directory is `firecrawl-cli`; the plugin's own validation rule (`commands/skill-gen.md` Step 7) requires the `name` field to match the directory name exactly.

**Evidence**: `head -2 skills/firecrawl-cli/SKILL.md` → `name: firecrawl`; directory is `skills/firecrawl-cli`; `commands/skill-gen.md` Step 7 states: "Has `name` field … `name` matches the parent directory name exactly".

**Fix**: Changed `name: firecrawl` to `name: firecrawl-cli` in the frontmatter.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->