### PR TITLE
fix: correct false claim that firecrawl-build/workflows are pre-installed

### DIFF
--- a/skills/firecrawl-cli/SKILL.md
+++ b/skills/firecrawl-cli/SKILL.md
@@ -13,7 +13,7 @@ Search, scrape, and interact with the web. Returns clean markdown optimized for 
 
 Run `firecrawl --help` or `firecrawl <command> --help` for full option details.
 
-If the task is to integrate Firecrawl into an application, add `FIRECRAWL_API_KEY` to a project, or choose endpoint usage in product code, use the `firecrawl-build` skills. If the task is an outcome workflow such as deep research, SEO audit, QA, lead generation, knowledge-base creation, dashboard reporting, shopping research, or website design-system extraction, use the `firecrawl-workflows` skills. They are already installed alongside this CLI skill when you run `firecrawl init`.
+If the task is to integrate Firecrawl into an application, add `FIRECRAWL_API_KEY` to a project, or choose endpoint usage in product code, use the `firecrawl-build` skills. If the task is an outcome workflow such as deep research, SEO audit, QA, lead generation, knowledge-base creation, dashboard reporting, shopping research, or website design-system extraction, use the `firecrawl-workflows` skills. These are separate plugins and must be installed independently.
 
 ## Prerequisites
 
@@ -221,8 +221,8 @@ Use `modes: ["json", "git-diff"]` for **mixed mode**: you get both `diff.json` (
 - **Detecting content changes on a website and getting notified by webhook or email (pricing, jobs, posts, docs, status pages, anything ongoing)** -> [firecrawl-monitor](../firecrawl-monitor/SKILL.md)
 - **Install, auth, or setup problems** -> [rules/install.md](rules/install.md)
 - **Output handling and safe file-reading patterns** -> [rules/security.md](rules/security.md)
-- **Integrating Firecrawl into an app, adding `FIRECRAWL_API_KEY` to `.env`, or choosing endpoint usage in product code** -> use the `firecrawl-build` skills (already installed alongside this CLI skill)
-- **Producing Firecrawl-powered deliverables such as research briefs, SEO audits, QA reports, lead lists, knowledge bases, or design-system extraction** -> use the `firecrawl-workflows` skills (already installed alongside this CLI skill). These skills infer from context first and ask only short blocking questions when needed.
+- **Integrating Firecrawl into an app, adding `FIRECRAWL_API_KEY` to `.env`, or choosing endpoint usage in product code** -> use the `firecrawl-build` skills (separate plugin, install independently)
+- **Producing Firecrawl-powered deliverables such as research briefs, SEO audits, QA reports, lead lists, knowledge bases, or design-system extraction** -> use the `firecrawl-workflows` skills (separate plugin, install independently). These skills infer from context first and ask only short blocking questions when needed.
 
 ## Output & Organization
 


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: \`skills/firecrawl-cli/SKILL.md\` states that \`firecrawl-build\` and \`firecrawl-workflows\` skill families are "already installed alongside this CLI skill when you run \`firecrawl init\`", but neither appears in \`.claude-plugin/plugin.json\`'s \`skills\` array; users following this guidance encounter missing-skill errors.

**Evidence**: \`cat .claude-plugin/plugin.json | jq '.skills'\` lists 10 skills — none named \`firecrawl-build\` or \`firecrawl-workflows\`; the text on L16 and L224–L225 claims they ship with this plugin.

**Fix**: Replaced "already installed alongside this CLI skill" with "separate plugins and must be installed independently" at all three locations.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->