### PR TITLE
sync Claude plugin skills (06e2fd5)

### DIFF
--- a/skills/firecrawl-monitor/SKILL.md
+++ b/skills/firecrawl-monitor/SKILL.md
@@ -63,6 +63,7 @@ Read [goals.md](goals.md) when writing or refining `--goal` (and `--queries` for
 
 ## Constraints & tips
 
+- Each check uses credits for its underlying scrape, crawl, or search, plus optional judging. See [Monitoring pricing](https://docs.firecrawl.dev/features/monitoring#pricing).
 - Minimum schedule interval is **5 minutes**. Monitoring is **not available for zero-data-retention teams**.
 - **Prefer one monitor over repeated one-off scrapes** whenever the user wants the same URL checked more than once.
 - **Silence temporarily with `update --state paused`**; reserve `delete` for monitors that are permanently done. (`--state` is an update flag; `--status` is the global CLI status flag.)

--- a/skills/firecrawl/rules/install.md
+++ b/skills/firecrawl/rules/install.md
@@ -15,7 +15,7 @@ description: |
 npx -y firecrawl-cli@latest init -y --browser
 ```
 
-This installs `firecrawl-cli` globally, authenticates via browser, and installs core, build, and workflow skills.
+This installs `firecrawl-cli` globally, authenticates via browser, and installs core and workflow skills. Build skills are a separate step: `firecrawl setup build`.
 
 This setup is safe to re-run when the CLI is missing, stale, or only partially configured.
 
@@ -31,6 +31,7 @@ To install skills manually:
 
 ```bash
 firecrawl setup skills
+firecrawl setup build
 firecrawl setup workflows
 ```
 


### PR DESCRIPTION
Automated sync of `skills/` and `.claude-plugin` from [firecrawl/cli@06e2fd5](https://github.com/firecrawl/cli/commit/06e2fd59d3a78051c8fcb05223b00aaff131267c).